### PR TITLE
Fix: Login redirects to the wrong portal

### DIFF
--- a/src/Arda.Main/Controllers/AccountController.cs
+++ b/src/Arda.Main/Controllers/AccountController.cs
@@ -117,7 +117,7 @@ namespace Arda.Main.Controllers
             
             await Util.ConnectToRemoteServiceString(HttpMethod.Post, Util.PermissionsURL + "api/permission/setuserpermissionsandcode?name=" + name, uniqueName, "");
 
-            return Redirect("/Dashboard/V2");
+            return Redirect("/Dashboard/");
         }
 
         public IActionResult SignIn()


### PR DESCRIPTION
* Redirect to /Dashboard instead of /Dashboard/v2